### PR TITLE
Fix adding empty source urls to sources dictionary

### DIFF
--- a/hanimetv/api.py
+++ b/hanimetv/api.py
@@ -30,7 +30,8 @@ class Video:
             for source in server["streams"]:
                 name = server["name"]
                 res = source["height"]
-                self.sources[f"{name}-{res}"] = source["url"]
+                if source["url"] != "":
+                    self.sources[f"{name}-{res}"] = source["url"]
         
         metadata["brand"] = json_enc["hentai_video"]["brand"]
         metadata["likes"] = json_enc["hentai_video"]["likes"]


### PR DESCRIPTION
This should fix the issues #17 and #18 as the empty source URLs were added to the sources dictionary, so the script tried to download the video from the empty URL